### PR TITLE
Compatible with the 2.6.27 version of libxml2

### DIFF
--- a/xmlreader.c
+++ b/xmlreader.c
@@ -703,7 +703,11 @@ xmlreader _xmlreader_from_string(const char *buffer, int size, const char *URL, 
     xmlFreeParserInputBuffer(buf);
     return (NULL);
   }
+#ifdef xmlTextReaderSetup // or #if LIBXML_VERSION >= 20628
   xmlTextReaderSetup(reader, buf, URL, encoding, options);
+#else
+  xmlReaderNewMemory(reader, buffer, size, URL, encoding, options);
+#end
   return (reader);
 }
 

--- a/xmlreader.c
+++ b/xmlreader.c
@@ -707,7 +707,7 @@ xmlreader _xmlreader_from_string(const char *buffer, int size, const char *URL, 
   xmlTextReaderSetup(reader, buf, URL, encoding, options);
 #else
   xmlReaderNewMemory(reader, buffer, size, URL, encoding, options);
-#end
+#endif
   return (reader);
 }
 


### PR DESCRIPTION
There isn't xmlTextReaderSetup below 2.6.28.